### PR TITLE
py_stringmatching 0.4.5 :snowflake:

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,3 @@
+upload_channels:
+  - sfe1ed40
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -51,9 +51,11 @@ about:
   license_file: LICENSE
   summary: Python library for string matching.
   description: |
-    This project seeks to build a Python software package that 
-    consists of a comprehensive and scalable set of string tokenizers 
-    (such as alphabetical tokenizers, whitespace tokenizers) and 
+    This project seeks to build a Python software package that
+    consists of a comprehensive and scalable set of string tokenizers
+    (such as alphabetical tokenizers, whitespace tokenizers) and
+    string similarity measures (such as edit distance, Jaccard,
+    TF/IDF).
   doc_url: https://anhaidgroup.github.io/py_stringmatching/
   dev_url: https://github.com/anhaidgroup/py_stringmatching
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,17 +1,18 @@
-{% set version = "0.4.3" %}
+{% set name = "py_stringmatching" %}
+{% set version = "0.4.5" %}
 
 package:
-  name: py_stringmatching
+  name: {{ name }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/p/py_stringmatching/py_stringmatching-{{ version }}.tar.gz
-  sha256: 921b9bb163b310df341c33823913204f7b0ca9f6a319f5b451408300bd378dee
+  url: https://pypi.io/packages/source/p/{{ name }}/py-stringmatching-{{ version }}.tar.gz
+  sha256: d97ba1b562ad98effc946687c5dab074c17a515114ab0dcf502202d5cec9f2b5
 
 build:
-  number: 1
-  skip: true  # [not x86_64]
-  script: {{ PYTHON }} -m pip install . --no-deps -vv
+  number: 0
+  #skip: true  # [not x86_64]
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
   build:
@@ -20,13 +21,13 @@ requirements:
   host:
     - python
     - pip
+    - setuptools
+    - wheel
     - cython
     - numpy
-    - six
   run:
     - python
     - {{ pin_compatible('numpy') }}
-    - six
 
 test:
   imports:
@@ -34,9 +35,13 @@ test:
     - py_stringmatching.similarity_measure
     - py_stringmatching.tests
     - py_stringmatching.tokenizer
+  requires:
+    - pip
+  commands:
+    - pip check
 
 about:
-  home: https://sites.google.com/site/anhaidgroup/projects/py_stringmatching
+  home: https://sites.google.com/site/anhaidgroup/current-projects/magellan/py_stringmatching
   license: BSD-3-Clause
   license_family: BSD
   license_file: LICENSE
@@ -45,7 +50,7 @@ about:
     This project seeks to build a Python software package that 
     consists of a comprehensive and scalable set of string tokenizers 
     (such as alphabetical tokenizers, whitespace tokenizers) and 
-  doc_url: http://anhaidgroup.github.io/py_stringmatching/
+  doc_url: https://anhaidgroup.github.io/py_stringmatching/
   dev_url: https://github.com/anhaidgroup/py_stringmatching
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,6 @@ source:
 
 build:
   number: 0
-  #skip: true  # [not x86_64]
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,6 +30,8 @@ requirements:
     - {{ pin_compatible('numpy') }}
 
 test:
+  source_files:
+    - py_stringmatching/tests
   imports:
     - py_stringmatching
     - py_stringmatching.similarity_measure
@@ -37,8 +39,10 @@ test:
     - py_stringmatching.tokenizer
   requires:
     - pip
+    - pytest
   commands:
     - pip check
+    - pytest -v py_stringmatching/tests
 
 about:
   home: https://sites.google.com/site/anhaidgroup/current-projects/magellan/py_stringmatching

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,7 +6,7 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/p/{{ name }}/py-stringmatching-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/py-stringmatching-{{ version }}.tar.gz
   sha256: d97ba1b562ad98effc946687c5dab074c17a515114ab0dcf502202d5cec9f2b5
 
 build:


### PR DESCRIPTION
py_stringmatching 0.4.5 :snowflake:

**Destination channel:** Snowflake

### Links

- [PKG-5066]
- dev_url:        https://github.com/anhaidgroup/py_stringmatching/tree/v0.4.5
- conda_forge:    https://github.com/conda-forge/py_stringmatching-feedstock/blob/main/recipe/meta.yaml
- pypi:           https://pypi.org/project/py_stringmatching/0.4.5
- pypi inspector: https://inspector.pypi.io/project/py_stringmatching/0.4.5

### Explanation of changes:

- basic build ignoring conda-forge restriction to `x86_64`
- add upstream tests


[PKG-5066]: https://anaconda.atlassian.net/browse/PKG-5066?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ